### PR TITLE
HEARTBEAT: Specify keepalive message type in handler

### DIFF
--- a/ros_alarms/alarms.py
+++ b/ros_alarms/alarms.py
@@ -4,6 +4,7 @@ import rostopic
 
 from ros_alarms.msg import Alarm
 from ros_alarms.srv import AlarmSet, AlarmGet, AlarmSetRequest, AlarmGetRequest
+from std_msgs.msg import Header
 
 import json
 
@@ -151,7 +152,7 @@ class AlarmListener(object):
                 rospy.logwarn(e)
 
 class HeartbeatMonitor(AlarmBroadcaster):
-    def __init__(self, alarm_name, topic_name, prd=0.2, predicate=None, nowarn=False, **kwargs):
+    def __init__(self, alarm_name, topic_name, prd=0.2, msg_class=Header, predicate=None, nowarn=False, **kwargs):
         ''' Used to trigger an alarm if a message on the topic `topic_name` isn't published
             atleast every `prd` seconds.
 
@@ -163,7 +164,6 @@ class HeartbeatMonitor(AlarmBroadcaster):
         self._dropped = False
         
         super(HeartbeatMonitor, self).__init__(alarm_name, nowarn=nowarn, **kwargs)
-        msg_class, _, _ = rostopic.get_topic_class(topic_name)
         rospy.Subscriber(topic_name, msg_class, self._got_msg)
 
         rospy.Timer(rospy.Duration(prd / 2), self._check_for_message)

--- a/tests/heartbeat_test.py
+++ b/tests/heartbeat_test.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     pub = rospy.Publisher("/heartbeat", String, queue_size=1)
     al = AlarmListener("kill")
     al.add_callback(printit, call_when_cleared=False)
-    hm = HeartbeatMonitor("kill", "/heartbeat", 1)
+    hm = HeartbeatMonitor("kill", "/heartbeat", 1, String)
     hm.clear_alarm()
 
     rospy.loginfo("Timeout test")
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     def parse(msg):
         return "test" in msg.data
 
-    hm = HeartbeatMonitor("kill", "/heartbeat", 1, parse)
+    hm = HeartbeatMonitor("kill", "/heartbeat", 1, String, parse)
     hm.clear_alarm()
 
     rospy.loginfo("Timeout with Predicate test")


### PR DESCRIPTION
The Heartbeat monitor will now default to expecting a Header message, but the user can specify the message type like in a subscriber. I ran into issues using the automatic message type deduction if the alarm sever is run before the keepalive node (this might happen in regular usage). I also think it's a good idea to be verbose about what type of message you are going to send.