### PR TITLE
CI: Add C++ and Python formatting as build checks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,12 @@ dockerNode(image: 'uf-mil:ros_alarms') {
 	}
 	stage("Format") {
 		sh '''
+			if [[ ! -z "$(python2.7 -m flake8 --max-line-length=120 --exclude=__init__.py .)" ]]; then
+				echo "The preceding Python following files are not formatted correctly"
+				exit 1
+			fi
+		'''
+		sh '''
 			source /opt/ros/kinetic/setup.bash > /dev/null 2>&1
 			wget -O ~/.clang-format https://raw.githubusercontent.com/uf-mil/installer/master/.clang-format
 			for FILE in $(find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp'); do

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ dockerNode(image: 'uf-mil:ros_alarms') {
 		checkout scm
 		sh '''
 			git submodule update --init --recursive
-			ln -s `pwd` ~/catkin_ws/src/ros_alarms
+			ln -s $PWD ~/catkin_ws/src/ros_alarms
 			git clone --recursive https://github.com/txros/txros ~/catkin_ws/src/txros
 		'''
 	}
@@ -19,6 +19,21 @@ dockerNode(image: 'uf-mil:ros_alarms') {
 			source ~/catkin_ws/devel/setup.bash > /dev/null 2>&1
 			catkin_make -C ~/catkin_ws run_tests
 			catkin_test_results ~/catkin_ws/build/test_results --verbose 
+		'''
+	}
+	stage("Format") {
+		sh '''
+			source /opt/ros/kinetic/setup.bash > /dev/null 2>&1
+			wget -O ~/.clang-format https://raw.githubusercontent.com/uf-mil/installer/master/.clang-format
+			for FILE in $(find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp'); do
+				if [ ! -z "$(clang-format-3.8 -style=file -output-replacements-xml $FILE | grep '<replacement ')" ]; then
+					FILES+=( "$FILE" )
+				fi
+			done
+			if (( ${#FILES[@]} > 0 )); then
+				echo "The C++ following files are not formatted correctly: ${FILES[@]}"
+				exit 1
+			fi
 		'''
 	}
 }

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -12,6 +12,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install sudo \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install lsb-release \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install git \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install wget \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install clang-format-3.8 \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y autoremove --purge \
 	&& apt-get -y clean \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -13,6 +13,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install lsb-release \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install git \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install wget \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install python-flake8 \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install clang-format-3.8 \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y autoremove --purge \
 	&& apt-get -y clean \


### PR DESCRIPTION
This adds a stage to the end of the build process that checks whether or not the new code is formatted according to our style guides. The build will fail if the files are not formatted correctly and a list of the ones that need to be changed for each language will be printed. See the [mil_common wiki](https://github.com/uf-mil/mil_common/wiki) for more information on how to automatically format code.

Have a look at [this Jenkins build](https://ci.mil.ufl.edu/jenkins/blue/organizations/jenkins/uf-mil%2Fros_alarms/detail/PR-20/9/pipeline) for this for information on what files need to be fixed. @DSsoto is handling the C++ formatting. If you worked on the Python code for ros_alarms, please update your code.

As each formatting pull request is merged to master, the build of this pull request should be run again by the user. Once all of the formatting checks pass, we can merge this. If you disagree with one of the formatting rules, feel free to debate it on this pull request and I will consider removing it.