### PR TITLE
TOOLS: add curses based cli to monitor and control an alarm

### DIFF
--- a/nodes/monitor
+++ b/nodes/monitor
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+import rospy
+from ros_alarms import AlarmListener, AlarmBroadcaster
+import curses
+import argparse
+
+__author__ = "Kevin Allen"
+
+
+class AlarmMonitor(object):
+    '''
+    Curses based terminal interface for monitoring and
+    controling an alarm.
+    '''
+    RAISE_KEYS = [ord('r'), 10, 32]  # r, Enter, Space; lots of keys for safety
+    CLEAR_KEYS = [ord('C')]  # Only capital C so it takes two keys to clear
+    COLOR_RAISED = 1  # Indexes for color profiles used in curses windows
+    COLOR_CLEARED = 2
+    COLOR_UNKNOWN = 3
+    # String to display on top of panel for usage instructions
+    HELP_STR = 'ROS Alarms CLI: Press ENTER to raise, C to clear'
+
+    def __init__(self, alarm_name, screen=None):
+        self.last_alarm = None
+        self.screen = screen
+        self.alarm_name = alarm_name
+        self.listener = AlarmListener(alarm_name)
+        self.listener.add_callback(self._alarm_cb)
+        self.broadcaster = AlarmBroadcaster(alarm_name)
+
+    def attach_screen(self, screen):
+        '''
+        Attach to curses window and displays graphical interface
+        until program quits
+        '''
+        self.screen = screen
+        self.screen.nodelay(True)
+        curses.curs_set(0)
+        curses.noecho()
+        curses.init_pair(self.COLOR_RAISED, curses.COLOR_WHITE, curses.COLOR_RED)
+        curses.init_pair(self.COLOR_CLEARED, curses.COLOR_WHITE, curses.COLOR_GREEN)
+        curses.init_pair(self.COLOR_UNKNOWN, curses.COLOR_BLACK, curses.COLOR_WHITE)
+        rospy.Timer(rospy.Duration(0.01), self._update_key)
+        self._draw()
+
+    def _alarm_cb(self, alm):
+        if alm.alarm_name == self.alarm_name:
+            self.last_alarm = alm
+            self._draw()
+
+    def _draw(self):
+        '''
+        Redraw the terminal, with a top line displaying
+        a help string and a box colored depending on alarm status
+        '''
+        if self.screen is None:
+            return
+        self.screen.clear()
+        self.screen.bkgd(' ', curses.color_pair(self.COLOR_UNKNOWN))
+        _, x = self.screen.getmaxyx()
+        # If box is too narrow, exclude help string
+        if x > len(self.HELP_STR):
+            self.screen.addstr(0, (x - len(self.HELP_STR)) / 2, self.HELP_STR)
+            status_window = self.screen.subwin(1, 0)
+        else:
+            status_window = self.screen.subwin(0, 0)
+
+        # Set a text string and background color for window depending on alarm status
+        status_str = 'UNKNOWN'
+        if self.last_alarm is not None:
+            if self.last_alarm.raised:
+                status_window.bkgd(' ', curses.color_pair(self.COLOR_RAISED))
+                status_str = 'RAISED'
+            else:
+                status_window.bkgd(' ', curses.color_pair(self.COLOR_CLEARED))
+                status_str = 'CLEARED'
+        else:
+            status_window.bkgd(' ', curses.color_pair(self.COLOR_UNKOWN))
+
+        height, width = status_window.getmaxyx()
+        # If window is too short to fit status, just display colored box
+        if height < 3:
+            return
+        if width >= len(self.alarm_name):  # If box is wide enough, display alarm name in center
+            status_window.addstr(height / 2 - 1, (width - len(self.alarm_name)) / 2, self.alarm_name)
+        if width >= len(status_str):       # If box is wide enough, display status text in center
+            status_window.addstr(height / 2 + 1, (width - len(status_str)) / 2, status_str)
+
+    def _read_key(self):
+        if self.screen is None:
+            return None
+        '''
+        Reads a single character from the terminal
+        Credit Anthony Olive
+        '''
+        keycode = -1
+        new_keycode = self.screen.getch()
+
+        # This eliminates building a buffer of keys that takes forever to process
+        while ((new_keycode != -1) and (not rospy.is_shutdown())):
+            keycode = new_keycode
+            new_keycode = self.screen.getch()
+
+        # The 'q' key can be used to quit the program
+        if (keycode == ord('q')):
+            rospy.signal_shutdown('user shutdown')
+        return keycode if keycode != -1 else None
+
+    def _update_key(self, _):
+        '''
+        Processes an inputed key and raises or clears alarm
+        if key in RAISE_KEYS or CLEAR_KEYS is entered.
+        '''
+        key = self._read_key()
+        if key is not None:
+            if key in self.RAISE_KEYS:
+                self.broadcaster.raise_alarm()
+            elif key in self.CLEAR_KEYS:
+                self.broadcaster.clear_alarm()
+
+
+if __name__ == "__main__":
+    # Grab alarm name from argv
+    parser = argparse.ArgumentParser(description='A curses interface for ros_alarms')
+    parser.add_argument('alarm', type=str, help='name of alarm to monitor and control')
+    args = parser.parse_args()
+
+    rospy.init_node('alarms_cli', anonymous=True)
+    cli = AlarmMonitor(args.alarm)
+    curses.wrapper(cli.attach_screen)
+    rospy.spin()

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -29,8 +29,10 @@ alias alist="rosparam get /known_alarms"
 alias araise="rosrun ros_alarms raise"
 alias aclear="rosrun ros_alarms clear"
 alias areport="rosrun ros_alarms report"
+alias amonitor="rosrun ros_alarms monitor"
 
 # Registers the autocompletion function to be invoked for ros_alarms aliases
 complete -F _alarm_complete araise
 complete -F _alarm_complete aclear
 complete -F _alarm_complete areport
+complete -F _alarm_complete amonitor


### PR DESCRIPTION
We've noticed that in testing SubjuGator the provided CLI for manually controlling alarms (the nodes/clear and nodes/kill scripts) are slow to raise/kill an alarm. This can take up to a few seconds, which can be a safety hazard. I created a curses based terminal interface which will stay connected to the alarm_server, raising or killing almost instantly by pressing ENTER or C. It also displays the current status with colors and is pretty.
![Killed screenshot](http://i.imgur.com/8UC0T2K.png)

![Cleared screenshot](http://i.imgur.com/eOi3Hk5.png)