### PR TITLE
MONITOR: fix bug on window resize

### DIFF
--- a/nodes/monitor
+++ b/nodes/monitor
@@ -12,13 +12,13 @@ class AlarmMonitor(object):
     Curses based terminal interface for monitoring and
     controling an alarm.
     '''
-    RAISE_KEYS = [ord('r'), 10, 32]  # r, Enter, Space; lots of keys for safety
+    RAISE_KEYS = [ord('r'), 32]  # r, SPACE to raise alarm
     CLEAR_KEYS = [ord('C')]  # Only capital C so it takes two keys to clear
     COLOR_RAISED = 1  # Indexes for color profiles used in curses windows
     COLOR_CLEARED = 2
     COLOR_UNKNOWN = 3
     # String to display on top of panel for usage instructions
-    HELP_STR = 'ROS Alarms CLI: Press ENTER to raise, C to clear'
+    HELP_STR = 'ROS Alarms CLI: Press SPACE to raise, C to clear'
 
     def __init__(self, alarm_name, screen=None):
         self.last_alarm = None


### PR DESCRIPTION
* remove ENTER from list of raise keys, as ENTER is triggered in curses on resize events